### PR TITLE
Simplify bash scripts with language arrays

### DIFF
--- a/data_util/extract_vectors_extrinsic.sh
+++ b/data_util/extract_vectors_extrinsic.sh
@@ -1,163 +1,40 @@
 #!/usr/bin/env bash
-
 FOLDER=../embeddings
 WORDFOLDER=../words/extrinsic
 OUTFOLDER=../saved_embeddings/extrinsic
-slang="es"
-
-
-for id in {1..2}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
+languages=("es" "de" "fi" "ru" "tr")
+for id in {1..2}; do
+  for langId in "${languages[@]}"; do
+    echo "Extracting ELMO for $langId for part: $id"
+    python3 extract_vectors.py \
     --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
+    --lang $langId \
+    --embedding "$FOLDER/elmo/$langId" \
     --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_es_$id.txt" \
+    --infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
     --savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_es_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_es_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-slang="fi"
-echo "Finnish"
-
-for id in {1..3}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
-    --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
+    echo "Extracting BPE for $langId for part: $id"
+    python3 extract_vectors.py \
+    --w2vtype "bpe" \
+    --lang $langId \
     --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_fi_$id.txt" \
+    --infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
     --savedir $OUTFOLDER
-done
-
-for id in {1..3}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_fi_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..3}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_fi_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-echo "Russian"
-slang="ru"
-
-
-for id in {1..6}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
-    --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
-    --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_ru_$id.txt" \
-    --savedir $OUTFOLDER
-done
-
-for id in {1..6}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_ru_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..6}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_ru_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-
-echo "Turkish"
-slang="tr"
-
-
-for id in {1..10}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
-    --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
-    --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_tr_$id.txt" \
-    --savedir $OUTFOLDER
-done
-
-for id in {1..10}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_tr_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..10}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_tr_$id.txt" \
-	--savedir $OUTFOLDER
+    echo "Extracting original fasttext for $langId for part: $id"
+    python3 extract_vectors.py \
+   	--w2vtype "fasttext" \
+   	--lang $langId \
+   	--embedding "$FOLDER/fasttext/wiki.$langId/wiki.$langId" \
+   	--part $id \
+   	--infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
+   	--savedir $OUTFOLDER
+    echo "Extracting muse supervised for $langId for part: $id"
+  	python3 extract_vectors.py \
+  	--w2vtype "muse_supervised" \
+  	--lang $langId \
+  	--embedding "$FOLDER/muse_supervised/wiki.multi.$langId/wiki.multi.$langId" \
+  	--part $id \
+  	--infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
+  	--savedir $OUTFOLDER
+  done
 done

--- a/data_util/extract_vectors_intrinsic.sh
+++ b/data_util/extract_vectors_intrinsic.sh
@@ -1,207 +1,40 @@
 #!/usr/bin/env bash
-
 FOLDER=../embeddings
 WORDFOLDER=../words/intrinsic
 OUTFOLDER=../saved_embeddings/intrinsic
-slang="es"
-
-
-for id in {1..2}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
+languages=("es" "de" "fi" "ru" "tr")
+for id in {1..2}; do
+  for langId in "${languages[@]}"; do
+    echo "Extracting ELMO for $langId for part: $id"
+    python3 extract_vectors.py \
     --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
+    --lang $langId \
+    --embedding "$FOLDER/elmo/$langId" \
     --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_es_$id.txt" \
+    --infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
     --savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_es_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting BPE for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "bpe" \
-	--lang $slang \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_es_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_es_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-slang="fi"
-echo "Finnish"
-
-for id in {1..2}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
-    --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
+    echo "Extracting BPE for $langId for part: $id"
+    python3 extract_vectors.py \
+    --w2vtype "bpe" \
+    --lang $langId \
     --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_fi_$id.txt" \
+    --infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
     --savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_fi_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting BPE for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "bpe" \
-	--lang $slang \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_fi_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_fi_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-echo "Russian"
-slang="ru"
-
-
-for id in {1..2}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
-    --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
-    --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_ru_$id.txt" \
-    --savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_ru_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting BPE for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "bpe" \
-	--lang $slang \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_ru_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_ru_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-
-echo "Turkish"
-slang="tr"
-
-
-for id in {1..2}
-do
-   echo "Extracting ELMO for "$slang" for part: "$id
-   python3 extract_vectors.py \
-    --w2vtype "elmo" \
-    --lang $slang \
-    --embedding "$FOLDER/elmo/$slang" \
-    --part $id \
-    --infile "$WORDFOLDER/$slang/splitted_tr_$id.txt" \
-    --savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting original fasttext for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "fasttext" \
-	--lang $slang \
-	--embedding "$FOLDER/fasttext/wiki.$slang/wiki.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_tr_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting BPE for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "bpe" \
-	--lang $slang \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_tr_$id.txt" \
-	--savedir $OUTFOLDER
-done
-
-for id in {1..2}
-do
-	echo "Extracting muse supervised for "$slang
-	python3 extract_vectors.py \
-	--w2vtype "muse_supervised" \
-	--lang $slang \
-	--embedding "$FOLDER/muse_supervised/wiki.multi.$slang/wiki.multi.$slang" \
-	--part $id \
-	--infile "$WORDFOLDER/$slang/splitted_tr_$id.txt" \
-	--savedir $OUTFOLDER
+    echo "Extracting original fasttext for $langId for part: $id"
+    python3 extract_vectors.py \
+   	--w2vtype "fasttext" \
+   	--lang $langId \
+   	--embedding "$FOLDER/fasttext/wiki.$langId/wiki.$langId" \
+   	--part $id \
+   	--infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
+   	--savedir $OUTFOLDER
+    echo "Extracting muse supervised for $langId for part: $id"
+  	python3 extract_vectors.py \
+  	--w2vtype "muse_supervised" \
+  	--lang $langId \
+  	--embedding "$FOLDER/muse_supervised/wiki.multi.$langId/wiki.multi.$langId" \
+  	--part $id \
+  	--infile "$WORDFOLDER/$langId/splitted_$langId_$id.txt" \
+  	--savedir $OUTFOLDER
+  done
 done

--- a/data_util/merge_files_extrinsic.sh
+++ b/data_util/merge_files_extrinsic.sh
@@ -1,48 +1,11 @@
 #!/usr/bin/env bash
-
-
 WORDFOLDER=../words/extrinsic
 EMBEDFOLDER=../saved_embeddings/extrinsic
-slang="es"
-
-# merge words and embeddings with space delimiter
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/bpe/embeds.vec > $EMBEDFOLDER/$slang/bpe/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/elmo/embeds.vec > $EMBEDFOLDER/$slang/elmo/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/fasttext/embeds.vec > $EMBEDFOLDER/$slang/fasttext/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/muse_supervised/embeds.vec > $EMBEDFOLDER/$slang/muse_supervised/final_embeds.vec
-
-
-slang="de"
-
-# merge words and embeddings with space delimiter
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/bpe/embeds.vec > $EMBEDFOLDER/$slang/bpe/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/elmo/embeds.vec > $EMBEDFOLDER/$slang/elmo/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/fasttext/embeds.vec > $EMBEDFOLDER/$slang/fasttext/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/muse_supervised/embeds.vec > $EMBEDFOLDER/$slang/muse_supervised/final_embeds.vec
-
-
-slang="tr"
-
-# merge words and embeddings with space delimiter
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/bpe/embeds.vec > $EMBEDFOLDER/$slang/bpe/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/elmo/embeds.vec > $EMBEDFOLDER/$slang/elmo/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/fasttext/embeds.vec > $EMBEDFOLDER/$slang/fasttext/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/muse_supervised/embeds.vec > $EMBEDFOLDER/$slang/muse_supervised/final_embeds.vec
-
-
-slang="ru"
-
-# merge words and embeddings with space delimiter
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/bpe/embeds.vec > $EMBEDFOLDER/$slang/bpe/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/elmo/embeds.vec > $EMBEDFOLDER/$slang/elmo/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/fasttext/embeds.vec > $EMBEDFOLDER/$slang/fasttext/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/muse_supervised/embeds.vec > $EMBEDFOLDER/$slang/muse_supervised/final_embeds.vec
-
-
-slang="fi"
-
-# merge words and embeddings with space delimiter
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/bpe/embeds.vec > $EMBEDFOLDER/$slang/bpe/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/elmo/embeds.vec > $EMBEDFOLDER/$slang/elmo/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/fasttext/embeds.vec > $EMBEDFOLDER/$slang/fasttext/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/muse_supervised/embeds.vec > $EMBEDFOLDER/$slang/muse_supervised/final_embeds.vec
+languages=("es" "de" "fi" "ru" "tr")
+for langId in "${languages[@]}"; do
+  # merge words and embeddings with space delimiter
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/bpe/embeds.vec > $EMBEDFOLDER/$langId/bpe/final_embeds.vec
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/elmo/embeds.vec > $EMBEDFOLDER/$langId/elmo/final_embeds.vec
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/fasttext/embeds.vec > $EMBEDFOLDER/$langId/fasttext/final_embeds.vec
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/muse_supervised/embeds.vec > $EMBEDFOLDER/$langId/muse_supervised/final_embeds.vec
+done

--- a/data_util/merge_files_intrinsic.sh
+++ b/data_util/merge_files_intrinsic.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-
-
-WORDFOLDER=../words/intrinsic_lower
-EMBEDFOLDER=../saved_embeddings/intrinsic_lower
-
-slang="de"
-
-# merge words and embeddings with space delimiter
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/elmo/embeds.vec > $EMBEDFOLDER/$slang/elmo/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/fasttext/embeds.vec > $EMBEDFOLDER/$slang/fasttext/final_embeds.vec
-paste -d ' ' $WORDFOLDER/$slang/$slang.txt $EMBEDFOLDER/$slang/muse_supervised/embeds.vec > $EMBEDFOLDER/$slang/muse_supervised/final_embeds.vec
-
-
+WORDFOLDER=../words/extrinsic
+EMBEDFOLDER=../saved_embeddings/extrinsic
+languages=("es" "de" "fi" "ru" "tr")
+for langId in "${languages[@]}"; do
+  # merge words and embeddings with space delimiter
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/bpe/embeds.vec > $EMBEDFOLDER/$langId/bpe/final_embeds.vec
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/elmo/embeds.vec > $EMBEDFOLDER/$langId/elmo/final_embeds.vec
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/fasttext/embeds.vec > $EMBEDFOLDER/$langId/fasttext/final_embeds.vec
+  paste -d ' ' $WORDFOLDER/$langId/$langId.txt $EMBEDFOLDER/$langId/muse_supervised/embeds.vec > $EMBEDFOLDER/$langId/muse_supervised/final_embeds.vec
+done


### PR DESCRIPTION
Moved duplicate code into a loop and set the same languages and embedding types for all scripts.